### PR TITLE
Fix speed in ZonePlayer Play function

### DIFF
--- a/AVTransport/AVTransport.go
+++ b/AVTransport/AVTransport.go
@@ -773,7 +773,7 @@ func (s *Service) Play(httpClient *http.Client, args *PlayArgs) (*PlayResponse, 
 		return nil, err
 	}
 	if r.Body.Play == nil {
-		return nil, errors.New(`unexpected respose from service calling avtransport.Play()`)
+		return nil, errors.New(`unexpected response from service calling avtransport.Play()`)
 	}
 
 	return r.Body.Play, nil

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/szatmary/sonos
+
+go 1.14

--- a/zoneplayer.go
+++ b/zoneplayer.go
@@ -223,7 +223,7 @@ func (z *ZonePlayer) SetVolume(desiredVolume int) error {
 
 func (z *ZonePlayer) Play() error {
 	_, err := z.AVTransport.Play(z.HttpClient, &avt.PlayArgs{
-		Speed: "1.0",
+		Speed: "1",
 	})
 	return err
 }


### PR DESCRIPTION
The Speed being "1.0" in the `zoneplayer.Play()` function caused my Sonoses to return errors.

I've also fixed a spelling mistake and added a `go.mod` file.